### PR TITLE
Add client and SSR loaders to enable importing server actions

### DIFF
--- a/apps/cloudflare-app/package.json
+++ b/apps/cloudflare-app/package.json
@@ -19,8 +19,8 @@
     "@mfng/core": "*",
     "@mfng/shared-app": "*",
     "history": "^5.3.0",
-    "react": "18.3.0-next-39a3b72c6-20230414",
-    "react-dom": "18.3.0-next-39a3b72c6-20230414"
+    "react": "18.3.0-next-d962f35ca-20230418",
+    "react-dom": "18.3.0-next-d962f35ca-20230418"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230221.0",
@@ -36,7 +36,7 @@
     "mini-css-extract-plugin": "^2.7.5",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.0.2",
-    "react-server-dom-webpack": "18.3.0-next-39a3b72c6-20230414",
+    "react-server-dom-webpack": "18.3.0-next-d962f35ca-20230418",
     "resolve-typescript-plugin": "^2.0.0",
     "swc-loader": "^0.2.3",
     "tailwindcss": "^3.2.7",

--- a/apps/shared-app/package.json
+++ b/apps/shared-app/package.json
@@ -21,7 +21,7 @@
     "clsx": "^1.2.1",
     "countries-list": "^2.6.1",
     "fuse.js": "^6.6.2",
-    "react": "18.3.0-next-39a3b72c6-20230414",
+    "react": "18.3.0-next-d962f35ca-20230418",
     "react-markdown": "^8.0.5",
     "server-only": "^0.0.1"
   },

--- a/apps/shared-app/src/client/button.tsx
+++ b/apps/shared-app/src/client/button.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+import {trackClick} from '../server/track-click.js';
+
+export type ButtonProps = React.PropsWithChildren<{
+  readonly disabled?: boolean;
+  readonly onClick: React.MouseEventHandler<HTMLButtonElement>;
+}>;
+
+export function Button({
+  children,
+  disabled,
+  onClick,
+}: ButtonProps): JSX.Element {
+  return (
+    <button
+      onClick={(event) => {
+        onClick(event);
+        void trackClick();
+      }}
+      disabled={disabled}
+      className="rounded-full bg-cyan-500 py-1 px-4 text-white disabled:bg-zinc-300"
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/shared-app/src/client/product.tsx
+++ b/apps/shared-app/src/client/product.tsx
@@ -2,17 +2,14 @@
 
 import * as React from 'react';
 import type {buy} from '../server/buy.js';
+import {Button} from './button.js';
 import {useEphemeralState} from './use-ephemeral-state.js';
 
-export interface BuyButtonProps {
+export interface ProductProps {
   readonly buy: typeof buy;
 }
 
-export function Foo(): null {
-  return null;
-}
-
-export function BuyButton({buy}: BuyButtonProps): JSX.Element {
+export function Product({buy}: ProductProps): JSX.Element {
   const [quantity, setQuantity] = React.useState(1);
   const [isPending, startTransition] = React.useTransition();
 
@@ -41,14 +38,9 @@ export function BuyButton({buy}: BuyButtonProps): JSX.Element {
         className="bg-zinc-100 p-1 outline-cyan-500"
       />
       {` `}
-      <button
-        onClick={handleClick}
-        disabled={isPending}
-        className="rounded-full bg-cyan-500 py-1 px-4 text-white disabled:bg-zinc-300"
-        type="button"
-      >
+      <Button onClick={handleClick} disabled={isPending}>
         Buy now
-      </button>
+      </Button>
       {/* Promises can now be rendered directly. */}
       {result as React.ReactNode}
     </div>

--- a/apps/shared-app/src/server/home-page.tsx
+++ b/apps/shared-app/src/server/home-page.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {BuyButton} from '../client/buy-button.js';
+import {Product} from '../client/product.js';
 import {Main} from '../shared/main.js';
 import {buy} from './buy.js';
 import {Hello} from './hello.js';
@@ -15,7 +15,7 @@ export function HomePage(): JSX.Element {
         <Suspended />
       </React.Suspense>
       <React.Suspense>
-        <BuyButton buy={buy} />
+        <Product buy={buy} />
       </React.Suspense>
     </Main>
   );

--- a/apps/shared-app/src/server/track-click.ts
+++ b/apps/shared-app/src/server/track-click.ts
@@ -5,6 +5,10 @@ import 'server-only';
 let clickCount = 0;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function trackClick(): Promise<void> {
-  console.log(`Clicked ${++clickCount} times.`);
+export async function trackClick(): Promise<number> {
+  clickCount++;
+
+  console.log(`Clicked ${clickCount} ${clickCount === 1 ? `time` : `times`}.`);
+
+  return clickCount;
 }

--- a/apps/shared-app/src/server/track-click.ts
+++ b/apps/shared-app/src/server/track-click.ts
@@ -1,0 +1,10 @@
+'use server';
+
+import 'server-only';
+
+let clickCount = 0;
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function trackClick(): Promise<void> {
+  console.log(`Clicked ${++clickCount} times.`);
+}

--- a/apps/vercel-app/package.json
+++ b/apps/vercel-app/package.json
@@ -19,8 +19,8 @@
     "@mfng/shared-app": "*",
     "@vercel/analytics": "^0.1.11",
     "history": "^5.3.0",
-    "react": "18.3.0-next-39a3b72c6-20230414",
-    "react-dom": "18.3.0-next-39a3b72c6-20230414",
+    "react": "18.3.0-next-d962f35ca-20230418",
+    "react-dom": "18.3.0-next-d962f35ca-20230418",
     "web-vitals": "^3.3.1"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "jest-config": "^29.5.0",
         "prettier": "^2.8.7",
         "prettier-plugin-tailwindcss": "^0.2.4",
-        "react-dom": "18.3.0-next-39a3b72c6-20230414",
+        "react-dom": "18.3.0-next-d962f35ca-20230418",
         "rimraf": "^4.4.1",
         "turbo": "^1.8.8",
         "typescript": "^4.9.5"
@@ -46,8 +46,8 @@
         "@mfng/core": "*",
         "@mfng/shared-app": "*",
         "history": "^5.3.0",
-        "react": "18.3.0-next-39a3b72c6-20230414",
-        "react-dom": "18.3.0-next-39a3b72c6-20230414"
+        "react": "18.3.0-next-d962f35ca-20230418",
+        "react-dom": "18.3.0-next-d962f35ca-20230418"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20230221.0",
@@ -63,7 +63,7 @@
         "mini-css-extract-plugin": "^2.7.5",
         "postcss": "^8.4.21",
         "postcss-loader": "^7.0.2",
-        "react-server-dom-webpack": "18.3.0-next-39a3b72c6-20230414",
+        "react-server-dom-webpack": "18.3.0-next-d962f35ca-20230418",
         "resolve-typescript-plugin": "^2.0.0",
         "swc-loader": "^0.2.3",
         "tailwindcss": "^3.2.7",
@@ -122,7 +122,7 @@
         "clsx": "^1.2.1",
         "countries-list": "^2.6.1",
         "fuse.js": "^6.6.2",
-        "react": "18.3.0-next-39a3b72c6-20230414",
+        "react": "18.3.0-next-d962f35ca-20230418",
         "react-markdown": "^8.0.5",
         "server-only": "^0.0.1"
       },
@@ -146,8 +146,8 @@
         "@mfng/shared-app": "*",
         "@vercel/analytics": "^0.1.11",
         "history": "^5.3.0",
-        "react": "18.3.0-next-39a3b72c6-20230414",
-        "react-dom": "18.3.0-next-39a3b72c6-20230414",
+        "react": "18.3.0-next-d962f35ca-20230418",
+        "react-dom": "18.3.0-next-d962f35ca-20230418",
         "web-vitals": "^3.3.1"
       },
       "devDependencies": {
@@ -16308,9 +16308,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.0-next-39a3b72c6-20230414",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0-next-39a3b72c6-20230414.tgz",
-      "integrity": "sha512-7lAq8yabg268nJlT6U95sG3ed6AmDcO+0SXOcKdPclItXgSklk8nRMw2vY7yx552hY+p2Odw+DusnWvqfWcNEA==",
+      "version": "18.3.0-next-d962f35ca-20230418",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0-next-d962f35ca-20230418.tgz",
+      "integrity": "sha512-oWi7eKbjk8wdGSv3rkvyWvQczq0ISdh/UBpiU9/V5ZE3Mm5tdGxpd/1Bi7ZhXR8+ogqM7pJ1jpZPicx4coQtLQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16319,21 +16319,21 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.0-next-39a3b72c6-20230414",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0-next-39a3b72c6-20230414.tgz",
-      "integrity": "sha512-EvYOPBV0tJ/HGunfadbEl+F1hR7P0LXdlQ9ksfDsQzta0JYc+XX8mEor9vRVhFR8TlEdRDISlSu2u16TIO+VhQ==",
+      "version": "18.3.0-next-d962f35ca-20230418",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0-next-d962f35ca-20230418.tgz",
+      "integrity": "sha512-sTXyrLTxP6HEM6pGbJBH+K9nrulyOSjABwX/zByl4unrTJO7c51Pl4sOEl9mymR2t1u4UwHhKYR7D9ZjE+cXXA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "0.24.0-next-39a3b72c6-20230414"
+        "scheduler": "0.24.0-next-d962f35ca-20230418"
       },
       "peerDependencies": {
-        "react": "18.3.0-next-39a3b72c6-20230414"
+        "react": "18.3.0-next-d962f35ca-20230418"
       }
     },
     "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.24.0-next-39a3b72c6-20230414",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-next-39a3b72c6-20230414.tgz",
-      "integrity": "sha512-UvG14yKTH146Ygr94EBfjtpB4BJoWNgEWTeerMaB3KHDEO3yEeh8By7Aj27Gmy7u+AeZSin3zeAWO7sxnEOrEA==",
+      "version": "0.24.0-next-d962f35ca-20230418",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-next-d962f35ca-20230418.tgz",
+      "integrity": "sha512-/gDGFb0D8ItqoqBcuNp7eqzPArgPy403oFbZ/W4tEzekHfqvrX+LdCN9XdPVejDaIf9CmnSg6f5YxS2GPQIYkA==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -16383,9 +16383,9 @@
       }
     },
     "node_modules/react-server-dom-webpack": {
-      "version": "18.3.0-next-39a3b72c6-20230414",
-      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-18.3.0-next-39a3b72c6-20230414.tgz",
-      "integrity": "sha512-IxARpEsxGQhcZNYwARFSroZCCxzdb4D7H/DDogojM8CLvOOmRnnWrgdyGKJJYJeS5gIuOqYlgR5Ww7arPyGxFA==",
+      "version": "18.3.0-next-d962f35ca-20230418",
+      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-18.3.0-next-d962f35ca-20230418.tgz",
+      "integrity": "sha512-HSBeC6uVeykWMMKd9IZOh8Az2TeTFGc1bnObSvEUvFQOE6KOHtl6/snwm4yfxBPLP2QbqesgRVFedMvgRfK2BA==",
       "dev": true,
       "dependencies": {
         "acorn-loose": "^8.3.0",
@@ -16396,8 +16396,8 @@
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "18.3.0-next-39a3b72c6-20230414",
-        "react-dom": "18.3.0-next-39a3b72c6-20230414",
+        "react": "18.3.0-next-d962f35ca-20230418",
+        "react-dom": "18.3.0-next-d962f35ca-20230418",
         "webpack": "^5.59.0"
       }
     },
@@ -20107,9 +20107,9 @@
         "@types/htmlescape": "^1.1.1",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "react": "18.3.0-next-39a3b72c6-20230414",
-        "react-dom": "18.3.0-next-39a3b72c6-20230414",
-        "react-server-dom-webpack": "18.3.0-next-39a3b72c6-20230414",
+        "react": "18.3.0-next-d962f35ca-20230418",
+        "react-dom": "18.3.0-next-d962f35ca-20230418",
+        "react-server-dom-webpack": "18.3.0-next-d962f35ca-20230418",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
@@ -20120,7 +20120,7 @@
     },
     "packages/webpack-rsc": {
       "name": "@mfng/webpack-rsc",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
@@ -20137,8 +20137,8 @@
         "@types/memory-fs": "^0.3.3",
         "memory-fs": "^0.5.0",
         "prettier": "^2.8.7",
-        "react": "18.3.0-next-39a3b72c6-20230414",
-        "react-server-dom-webpack": "18.3.0-next-39a3b72c6-20230414",
+        "react": "18.3.0-next-d962f35ca-20230418",
+        "react-server-dom-webpack": "18.3.0-next-d962f35ca-20230418",
         "typescript": "^4.9.5",
         "webpack": "^5.75.0"
       },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jest-config": "^29.5.0",
     "prettier": "^2.8.7",
     "prettier-plugin-tailwindcss": "^0.2.4",
-    "react-dom": "18.3.0-next-39a3b72c6-20230414",
+    "react-dom": "18.3.0-next-d962f35ca-20230418",
     "rimraf": "^4.4.1",
     "turbo": "^1.8.8",
     "typescript": "^4.9.5"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,9 +34,9 @@
     "@types/htmlescape": "^1.1.1",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "react": "18.3.0-next-39a3b72c6-20230414",
-    "react-dom": "18.3.0-next-39a3b72c6-20230414",
-    "react-server-dom-webpack": "18.3.0-next-39a3b72c6-20230414",
+    "react": "18.3.0-next-d962f35ca-20230418",
+    "react-dom": "18.3.0-next-d962f35ca-20230418",
+    "react-server-dom-webpack": "18.3.0-next-d962f35ca-20230418",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {

--- a/packages/webpack-rsc/README.md
+++ b/packages/webpack-rsc/README.md
@@ -2,9 +2,9 @@
 
 ⚠️ **Experimental**
 
-This library provides a Webpack loader and a pair of Webpack plugins for
-integrating React Server Components (RSC) and Server-Side Rendering (SSR) in a
-React application that can be deployed to the edge.
+This library provides a set of Webpack loaders and plugins for integrating React
+Server Components (RSC) and Server-Side Rendering (SSR) in a React application
+that can be deployed to the edge.
 
 > Disclaimer: There are many moving parts involved in creating an RSC app that
 > also handles SSR, without using a framework like Next.js. This library only
@@ -21,23 +21,25 @@ To use this library in your React Server Components project, follow these steps:
 npm install --save-dev @mfng/webpack-rsc
 ```
 
-2. Update your `webpack.config.js` to include the loader and plugins provided by
-   this library. See the example configuration below for reference.
+2. Update your `webpack.config.js` to include the loaders and plugins provided
+   by this library. See the example configuration below for reference.
 
 ## Example Webpack Configuration
 
-The following example demonstrates how to use the loader and plugins in a
+The following example demonstrates how to use the loaders and plugins in a
 Webpack configuration:
 
 ```js
 import {
   WebpackRscClientPlugin,
   WebpackRscServerPlugin,
+  createWebpackRscClientLoader,
   createWebpackRscServerLoader,
   webpackRscLayerName,
 } from '@mfng/webpack-rsc';
 
 const clientReferencesMap = new Map();
+const serverReferencesMap = new Map();
 
 const serverConfig = {
   name: 'server',
@@ -68,7 +70,9 @@ const serverConfig = {
       },
     ],
   },
-  plugins: [new WebpackRscServerPlugin({clientReferencesMap})],
+  plugins: [
+    new WebpackRscServerPlugin({clientReferencesMap, serverReferencesMap}),
+  ],
   experiments: {layers: true},
   // ...
 };
@@ -77,7 +81,17 @@ const clientConfig = {
   name: 'client',
   dependencies: ['server'],
   // ...
-  module: {rules: [{test: /\.tsx?$/, loader: 'swc-loader'}]},
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: [
+          createWebpackRscClientLoader({serverReferencesMap}),
+          'swc-loader',
+        ],
+      },
+    ],
+  },
   plugins: [new WebpackRscClientPlugin({clientReferencesMap})],
   // ...
 };
@@ -88,17 +102,17 @@ export default [serverConfig, clientConfig];
 **Note:** It's important to specify the names and dependencies of the configs as
 shown above, so that the plugins work in the correct order, even in watch mode.
 
-## Webpack Loader and Plugins
+## Webpack Loaders and Plugins
 
-This library provides the following Webpack loader and plugins:
+This library provides the following Webpack loaders and plugins:
 
 ### `createWebpackRscServerLoader`
 
-A function to create the RSC server loader `use` item. This loader is
-responsible for replacing client components in a `use client` module with client
-references (objects that contain meta data about the client components), and
-removing all other parts of the client module. It also populates the
-`clientReferencesMap`.
+A function to create the RSC server loader `use` item for the server entry
+webpack config. This loader is responsible for replacing client components in a
+`use client` module with client references (objects that contain meta data about
+the client components), and removing all other parts of the client module. It
+also populates the given `clientReferencesMap`.
 
 ### `WebpackRscServerPlugin`
 
@@ -110,7 +124,20 @@ The plugin also handles server references for React server actions by adding
 meta data to all exported functions of a `use server` module. Based on this, it
 generates the server manifest that is needed for validating the server
 references for server actions (also known as mutations) that are sent back from
-the client.
+the client. It also populates the given `serverReferencesMap`.
+
+### `createWebpackRscClientLoader`
+
+A function to create the RSC client loader `use` item for the client entry
+webpack config. This loader is responsible for replacing server actions in a
+`use server` module with server references (based on the given
+`serverReferencesMap`), and removing all other parts of the server module, so
+that the server module can be imported from a client module.
+
+**Note:** Importing server actions from a client module requires that
+`callServer` can be imported from a module. Per default `@mfng/core/client` is
+used as import source, but this can be customized with the
+`callServerImportSource` option.
 
 ### `WebpackRscClientPlugin`
 

--- a/packages/webpack-rsc/package.json
+++ b/packages/webpack-rsc/package.json
@@ -35,8 +35,8 @@
     "@types/memory-fs": "^0.3.3",
     "memory-fs": "^0.5.0",
     "prettier": "^2.8.7",
-    "react": "18.3.0-next-39a3b72c6-20230414",
-    "react-server-dom-webpack": "18.3.0-next-39a3b72c6-20230414",
+    "react": "18.3.0-next-d962f35ca-20230418",
+    "react-server-dom-webpack": "18.3.0-next-d962f35ca-20230418",
     "typescript": "^4.9.5",
     "webpack": "^5.75.0"
   },

--- a/packages/webpack-rsc/package.json
+++ b/packages/webpack-rsc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mfng/webpack-rsc",
-  "version": "2.0.2",
-  "description": "A Webpack loader and a pair of plugins for React Server Components",
+  "version": "2.1.0",
+  "description": "A set of Webpack loaders and plugins for React Server Components",
   "repository": {
     "type": "git",
     "url": "https://github.com/unstubbable/mfng.git",

--- a/packages/webpack-rsc/src/__fixtures__/client-component-with-server-action.js
+++ b/packages/webpack-rsc/src/__fixtures__/client-component-with-server-action.js
@@ -1,0 +1,13 @@
+// @ts-nocheck
+'use client';
+
+import * as React from 'react';
+import {serverFunction} from './server-function.js';
+
+export function ClientComponentWithServerAction() {
+  React.useEffect(() => {
+    serverFunction().then(console.log);
+  }, []);
+
+  return null;
+}

--- a/packages/webpack-rsc/src/__fixtures__/client-components.js
+++ b/packages/webpack-rsc/src/__fixtures__/client-components.js
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import {ClientComponentWithServerAction} from './client-component-with-server-action.js';
 
 export function ComponentA() {
   return React.createElement(`div`);
@@ -11,5 +12,5 @@ export const ComponentB = function () {
 };
 
 export const ComponentC = () => {
-  return React.createElement(`div`);
+  return React.createElement(ClientComponentWithServerAction);
 };

--- a/packages/webpack-rsc/src/__fixtures__/server-functions.js
+++ b/packages/webpack-rsc/src/__fixtures__/server-functions.js
@@ -1,0 +1,9 @@
+'use server';
+
+export async function foo() {
+  return Promise.resolve(`foo`);
+}
+
+export const bar = async () => Promise.resolve(`bar`);
+
+export const baz = 42;

--- a/packages/webpack-rsc/src/index.ts
+++ b/packages/webpack-rsc/src/index.ts
@@ -7,15 +7,21 @@ export * from './webpack-rsc-client-loader.cjs';
 export * from './webpack-rsc-client-plugin.js';
 export * from './webpack-rsc-server-loader.cjs';
 export * from './webpack-rsc-server-plugin.js';
+export * from './webpack-rsc-ssr-loader.cjs';
 
 const require = createRequire(import.meta.url);
 const serverLoader = require.resolve(`./webpack-rsc-server-loader.cjs`);
+const ssrLoader = require.resolve(`./webpack-rsc-ssr-loader.cjs`);
 const clientLoader = require.resolve(`./webpack-rsc-client-loader.cjs`);
 
 export function createWebpackRscServerLoader(
   options: WebpackRscServerLoaderOptions,
 ): RuleSetUseItem {
   return {loader: serverLoader, options};
+}
+
+export function createWebpackRscSsrLoader(): RuleSetUseItem {
+  return {loader: ssrLoader};
 }
 
 export function createWebpackRscClientLoader(

--- a/packages/webpack-rsc/src/index.ts
+++ b/packages/webpack-rsc/src/index.ts
@@ -1,16 +1,25 @@
 import {createRequire} from 'module';
 import type {RuleSetUseItem} from 'webpack';
+import type {WebpackRscClientLoaderOptions} from './webpack-rsc-client-loader.cjs';
 import type {WebpackRscServerLoaderOptions} from './webpack-rsc-server-loader.cjs';
 
+export * from './webpack-rsc-client-loader.cjs';
 export * from './webpack-rsc-client-plugin.js';
 export * from './webpack-rsc-server-loader.cjs';
 export * from './webpack-rsc-server-plugin.js';
 
 const require = createRequire(import.meta.url);
-const loader = require.resolve(`./webpack-rsc-server-loader.cjs`);
+const serverLoader = require.resolve(`./webpack-rsc-server-loader.cjs`);
+const clientLoader = require.resolve(`./webpack-rsc-client-loader.cjs`);
 
 export function createWebpackRscServerLoader(
   options: WebpackRscServerLoaderOptions,
 ): RuleSetUseItem {
-  return {loader, options};
+  return {loader: serverLoader, options};
+}
+
+export function createWebpackRscClientLoader(
+  options: WebpackRscClientLoaderOptions,
+): RuleSetUseItem {
+  return {loader: clientLoader, options};
 }

--- a/packages/webpack-rsc/src/webpack-rsc-client-loader.cts
+++ b/packages/webpack-rsc/src/webpack-rsc-client-loader.cts
@@ -34,12 +34,8 @@ export default function webpackRscClientLoader(
   });
 
   traverse(ast, {
-    enter(path) {
+    Program(path) {
       const {node} = path;
-
-      if (!t.isProgram(node)) {
-        return;
-      }
 
       if (!node.directives.some(isUseServerDirective)) {
         return;

--- a/packages/webpack-rsc/src/webpack-rsc-client-loader.cts
+++ b/packages/webpack-rsc/src/webpack-rsc-client-loader.cts
@@ -1,0 +1,114 @@
+import generate from '@babel/generator';
+import {parse} from '@babel/parser';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type {LoaderContext} from 'webpack';
+
+export interface WebpackRscClientLoaderOptions {
+  readonly serverReferencesMap: ServerReferencesMap;
+  readonly callServerImportSource?: string;
+}
+
+export type ServerReferencesMap = Map<string, ServerReferencesModuleInfo>;
+
+export interface ServerReferencesModuleInfo {
+  readonly moduleId: string | number;
+  readonly exportNames: string[];
+}
+
+export default function webpackRscClientLoader(
+  this: LoaderContext<WebpackRscClientLoaderOptions>,
+  source: string,
+): void {
+  this.cacheable(true);
+
+  const {serverReferencesMap, callServerImportSource = `@mfng/core/client`} =
+    this.getOptions();
+
+  const loaderContext = this;
+  const resourcePath = this.resourcePath;
+
+  const ast = parse(source, {
+    sourceType: `module`,
+    sourceFilename: resourcePath,
+  });
+
+  traverse(ast, {
+    enter(path) {
+      const {node} = path;
+
+      if (!t.isProgram(node)) {
+        return;
+      }
+
+      if (!node.directives.some(isUseServerDirective)) {
+        return;
+      }
+
+      const moduleInfo = serverReferencesMap.get(resourcePath);
+
+      if (!moduleInfo) {
+        loaderContext.emitError(
+          new Error(
+            `Could not find server references module info in \`serverReferencesMap\` for ${resourcePath}.`,
+          ),
+        );
+
+        path.replaceWith(t.program([]));
+
+        return;
+      }
+
+      const {moduleId, exportNames} = moduleInfo;
+
+      path.replaceWith(
+        t.program([
+          t.importDeclaration(
+            [
+              t.importSpecifier(
+                t.identifier(`createServerReference`),
+                t.identifier(`createServerReference`),
+              ),
+            ],
+            t.stringLiteral(`react-server-dom-webpack/client`),
+          ),
+          t.importDeclaration(
+            [
+              t.importSpecifier(
+                t.identifier(`callServer`),
+                t.identifier(`callServer`),
+              ),
+            ],
+            t.stringLiteral(callServerImportSource),
+          ),
+          ...exportNames.map((exportName) =>
+            t.exportNamedDeclaration(
+              t.variableDeclaration(`const`, [
+                t.variableDeclarator(
+                  t.identifier(exportName),
+                  t.callExpression(t.identifier(`createServerReference`), [
+                    t.stringLiteral(`${moduleId}#${exportName}`),
+                    t.identifier(`callServer`),
+                  ]),
+                ),
+              ]),
+            ),
+          ),
+        ]),
+      );
+    },
+  });
+
+  const {code} = generate(ast, {sourceFileName: this.resourcePath});
+
+  // TODO: Handle source maps.
+
+  this.callback(null, code);
+}
+
+function isUseServerDirective(directive: t.Directive): boolean {
+  return (
+    t.isDirectiveLiteral(directive.value) &&
+    directive.value.value === `use server`
+  );
+}

--- a/packages/webpack-rsc/src/webpack-rsc-client-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-client-loader.test.ts
@@ -1,0 +1,151 @@
+import fs from 'fs/promises';
+import path from 'path';
+import url from 'url';
+import {jest} from '@jest/globals';
+import type webpack from 'webpack';
+import type {
+  ServerReferencesMap,
+  WebpackRscClientLoaderOptions,
+} from './webpack-rsc-client-loader.cjs';
+import webpackRscClientLoader from './webpack-rsc-client-loader.cjs';
+
+const currentDirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+async function callLoader(
+  resourcePath: string,
+  options: WebpackRscClientLoaderOptions,
+  emitError?: jest.Mock<(error: Error) => void>,
+): Promise<string | Buffer> {
+  const input = await fs.readFile(resourcePath);
+
+  return new Promise((resolve, reject) => {
+    const context: Partial<
+      webpack.LoaderContext<WebpackRscClientLoaderOptions>
+    > = {
+      getOptions: () => options,
+      resourcePath,
+      cacheable: jest.fn(),
+      emitError,
+      callback: (error, content) => {
+        if (error) {
+          reject(error);
+        } else if (content !== undefined) {
+          resolve(content);
+        } else {
+          reject(
+            new Error(
+              `Did not receive any content from webpackRscClientLoader.`,
+            ),
+          );
+        }
+      },
+    };
+
+    void webpackRscClientLoader.default.call(
+      context as webpack.LoaderContext<WebpackRscClientLoaderOptions>,
+      input.toString(`utf-8`),
+    );
+  });
+}
+
+describe(`webpackRscClientLoader`, () => {
+  test(`generates a server reference module based on given serverReferencesMap`, async () => {
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/server-function.js`,
+    );
+
+    const serverReferencesMap: ServerReferencesMap = new Map([
+      [resourcePath, {moduleId: `test`, exportNames: [`foo`, `bar`]}],
+    ]);
+
+    const output = await callLoader(resourcePath, {serverReferencesMap});
+
+    expect(output).toEqual(
+      `
+import { createServerReference } from "react-server-dom-webpack/client";
+import { callServer } from "@mfng/core/client";
+export const foo = createServerReference("test#foo", callServer);
+export const bar = createServerReference("test#bar", callServer);
+`.trim(),
+    );
+  });
+
+  test(`accepts a custom callServer import source`, async () => {
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/server-function.js`,
+    );
+
+    const serverReferencesMap: ServerReferencesMap = new Map([
+      [resourcePath, {moduleId: `test`, exportNames: [`foo`]}],
+    ]);
+
+    const callServerImportSource = `some-router/call-server`;
+
+    const output = await callLoader(resourcePath, {
+      serverReferencesMap,
+      callServerImportSource,
+    });
+
+    expect(output).toEqual(
+      `
+import { createServerReference } from "react-server-dom-webpack/client";
+import { callServer } from "some-router/call-server";
+export const foo = createServerReference("test#foo", callServer);
+`.trim(),
+    );
+  });
+
+  test(`emits an error if module info is missing in serverReferencesMap`, async () => {
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/server-function.js`,
+    );
+
+    const serverReferencesMap: ServerReferencesMap = new Map();
+    const emitError = jest.fn();
+
+    const output = await callLoader(
+      resourcePath,
+      {serverReferencesMap},
+      emitError,
+    );
+
+    expect(emitError.mock.calls).toEqual([
+      [
+        new Error(
+          `Could not find server references module info in \`serverReferencesMap\` for ${resourcePath}.`,
+        ),
+      ],
+    ]);
+
+    expect(output).toEqual(``);
+  });
+
+  test(`does not change modules without a 'use server' directive`, async () => {
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/client-component.js`,
+    );
+
+    const serverReferencesMap = new Map();
+    const output = await callLoader(resourcePath, {serverReferencesMap});
+
+    expect(output).toEqual(
+      `
+// @ts-nocheck
+'use client';
+
+import * as React from 'react';
+export function ClientComponent({
+  action
+}) {
+  React.useEffect(() => {
+    action().then(console.log);
+  }, []);
+  return null;
+}`.trim(),
+    );
+  });
+});

--- a/packages/webpack-rsc/src/webpack-rsc-server-loader.cts
+++ b/packages/webpack-rsc/src/webpack-rsc-server-loader.cts
@@ -47,6 +47,7 @@ export default function webpackRscServerLoader(
 
       if (t.isDirective(node) && isUseClientDirective(node)) {
         path.skip();
+
         return;
       }
 

--- a/packages/webpack-rsc/src/webpack-rsc-server-plugin.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-server-plugin.test.ts
@@ -97,7 +97,7 @@ describe(`WebpackRscServerPlugin`, () => {
 
       expect(outputFile).toMatch(
         `
-/***/ "./packages/webpack-rsc/src/__fixtures__/server-function.js":
+/***/ "(react-server)/./packages/webpack-rsc/src/__fixtures__/server-function.js":
 /*!******************************************************************!*\\
   !*** ./packages/webpack-rsc/src/__fixtures__/server-function.js ***!
   \\******************************************************************/
@@ -114,7 +114,7 @@ async function serverFunction() {
 }
 Object.defineProperties(serverFunction, {
 	$$typeof: {value: Symbol.for("react.server.reference")},
-	$$id: {value: "./packages/webpack-rsc/src/__fixtures__/server-function.js#serverFunction"},
+	$$id: {value: "(react-server)/./packages/webpack-rsc/src/__fixtures__/server-function.js#serverFunction"},
 });
 
 /***/ })`,
@@ -130,9 +130,8 @@ Object.defineProperties(serverFunction, {
       );
 
       expect(JSON.parse(manifestFile)).toEqual({
-        './packages/webpack-rsc/src/__fixtures__/server-function.js': [
-          `serverFunction`,
-        ],
+        '(react-server)/./packages/webpack-rsc/src/__fixtures__/server-function.js':
+          [`serverFunction`],
       });
     });
 
@@ -143,7 +142,7 @@ Object.defineProperties(serverFunction, {
         [
           path.resolve(currentDirname, `./__fixtures__/server-function.js`),
           {
-            moduleId: `./packages/webpack-rsc/src/__fixtures__/server-function.js`,
+            moduleId: `(react-server)/./packages/webpack-rsc/src/__fixtures__/server-function.js`,
             exportNames: [`serverFunction`],
           },
         ],
@@ -156,7 +155,7 @@ Object.defineProperties(serverFunction, {
 
     beforeEach(() => {
       buildConfig = {...buildConfig, mode: `production`};
-      expectedModuleId = 269; // may change in the future
+      expectedModuleId = 340; // may change in the future
     });
 
     test(`the generated bundle has replacement code for server references`, async () => {

--- a/packages/webpack-rsc/src/webpack-rsc-ssr-loader.cts
+++ b/packages/webpack-rsc/src/webpack-rsc-ssr-loader.cts
@@ -1,0 +1,106 @@
+import generate from '@babel/generator';
+import {parse} from '@babel/parser';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type {LoaderContext} from 'webpack';
+
+export default function webpackRscSsrLoader(
+  this: LoaderContext<{}>,
+  source: string,
+): void {
+  this.cacheable(true);
+
+  const resourcePath = this.resourcePath;
+
+  const ast = parse(source, {
+    sourceType: `module`,
+    sourceFilename: resourcePath,
+  });
+
+  traverse(ast, {
+    enter(path) {
+      const {node} = path;
+
+      if (t.isProgram(node)) {
+        if (!node.directives.some(isUseServerDirective)) {
+          path.skip();
+        }
+
+        return;
+      }
+
+      if (t.isDirective(node) && isUseServerDirective(node)) {
+        path.skip();
+
+        return;
+      }
+
+      const exportName = getFunctionExportName(node);
+
+      if (exportName) {
+        path.replaceWith(createExportedServerReferenceStub(exportName));
+        path.skip();
+      } else {
+        path.remove();
+      }
+    },
+  });
+
+  const {code} = generate(ast, {sourceFileName: this.resourcePath});
+
+  // TODO: Handle source maps.
+
+  this.callback(null, code);
+}
+
+function isUseServerDirective(directive: t.Directive): boolean {
+  return (
+    t.isDirectiveLiteral(directive.value) &&
+    directive.value.value === `use server`
+  );
+}
+
+function getFunctionExportName(node: t.Node): string | undefined {
+  if (t.isExportNamedDeclaration(node)) {
+    if (t.isFunctionDeclaration(node.declaration)) {
+      return node.declaration.id?.name;
+    }
+
+    if (t.isVariableDeclaration(node.declaration)) {
+      const declarator = node.declaration.declarations[0];
+
+      if (!declarator) {
+        return undefined;
+      }
+
+      if (
+        t.isFunctionExpression(declarator.init) ||
+        t.isArrowFunctionExpression(declarator.init)
+      ) {
+        return t.isIdentifier(declarator.id) ? declarator.id.name : undefined;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function createExportedServerReferenceStub(
+  exportName: string,
+): t.ExportNamedDeclaration {
+  return t.exportNamedDeclaration(
+    t.functionDeclaration(
+      t.identifier(exportName),
+      [],
+      t.blockStatement([
+        t.throwStatement(
+          t.newExpression(t.identifier(`Error`), [
+            t.stringLiteral(
+              `Server actions must not be called during server-side rendering.`,
+            ),
+          ]),
+        ),
+      ]),
+    ),
+  );
+}

--- a/packages/webpack-rsc/src/webpack-rsc-ssr-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-ssr-loader.test.ts
@@ -1,0 +1,84 @@
+import fs from 'fs/promises';
+import path from 'path';
+import url from 'url';
+import {jest} from '@jest/globals';
+import type webpack from 'webpack';
+import webpackRscSsrLoader from './webpack-rsc-ssr-loader.cjs';
+
+const currentDirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+async function callLoader(resourcePath: string): Promise<string | Buffer> {
+  const input = await fs.readFile(resourcePath);
+
+  return new Promise((resolve, reject) => {
+    const context: Partial<webpack.LoaderContext<{}>> = {
+      resourcePath,
+      cacheable: jest.fn(),
+      callback: (error, content) => {
+        if (error) {
+          reject(error);
+        } else if (content !== undefined) {
+          resolve(content);
+        } else {
+          reject(
+            new Error(`Did not receive any content from webpackRscSsrLoader.`),
+          );
+        }
+      },
+    };
+
+    void webpackRscSsrLoader.default.call(
+      context as webpack.LoaderContext<{}>,
+      input.toString(`utf-8`),
+    );
+  });
+}
+
+describe(`webpackRscSsrLoader`, () => {
+  test(`generates stubs for all function exports of a server reference module, and removes the rest`, async () => {
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/server-functions.js`,
+    );
+
+    const output = await callLoader(resourcePath);
+
+    expect(output).toEqual(
+      `
+'use server';
+
+export function foo() {
+  throw new Error("Server actions must not be called during server-side rendering.");
+}
+export function bar() {
+  throw new Error("Server actions must not be called during server-side rendering.");
+}
+`.trim(),
+    );
+  });
+
+  test(`does not change modules without a 'use server' directive`, async () => {
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/client-component.js`,
+    );
+
+    const output = await callLoader(resourcePath);
+
+    expect(output).toEqual(
+      `
+// @ts-nocheck
+'use client';
+
+import * as React from 'react';
+export function ClientComponent({
+  action
+}) {
+  React.useEffect(() => {
+    action().then(console.log);
+  }, []);
+  return null;
+}`.trim(),
+    );
+  });
+});

--- a/types/react-server-dom-webpack-client.browser.d.ts
+++ b/types/react-server-dom-webpack-client.browser.d.ts
@@ -28,4 +28,9 @@ declare module 'react-server-dom-webpack/client.browser' {
   export function encodeReply(
     value: ReactServerValue,
   ): Promise<string | FormData>;
+
+  export function createServerReference(
+    id: string,
+    callServer: CallServerCallback,
+  ): (...args: unknown[]) => Promise<unknown>;
 }


### PR DESCRIPTION
Made easier by https://github.com/facebook/react/pull/26632

- [x] requires new `next` release of react