### PR TITLE
Re-introduce `<ServerRoot />`

### DIFF
--- a/packages/core/src/server/create-html-stream.tsx
+++ b/packages/core/src/server/create-html-stream.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import ReactDOMServer from 'react-dom/server.browser';
 import type {SSRManifest} from 'react-server-dom-webpack';
 import ReactServerDOMClient from 'react-server-dom-webpack/client.edge';
@@ -18,10 +19,14 @@ export async function createHtmlStream(
   const {reactSsrManifest, bootstrapScripts} = options;
   const [rscStream1, rscStream2] = rscStream.tee();
 
-  const htmlStream = await ReactDOMServer.renderToReadableStream(
-    await ReactServerDOMClient.createFromReadableStream(rscStream1, {
+  const ServerRoot = (): JSX.Element =>
+    // @ts-expect-error should be fixed with TS 5.1
+    ReactServerDOMClient.createFromReadableStream(rscStream1, {
       moduleMap: reactSsrManifest,
-    }),
+    });
+
+  const htmlStream = await ReactDOMServer.renderToReadableStream(
+    <ServerRoot />,
     {
       bootstrapScriptContent: rscResponseStreamBootstrapScriptContent,
       bootstrapScripts,


### PR DESCRIPTION
This is in preparation for the upcoming React feature of adding preload link elements for client chunks that are needed for hydration.

See the following discussion for more details: https://github.com/facebook/react/pull/26664#discussion_r1172036837