### PR TITLE
Remove unnecessary `types` entries in conditional exports

### DIFF
--- a/apps/shared-app/package.json
+++ b/apps/shared-app/package.json
@@ -8,13 +8,11 @@
   "exports": {
     "./app.js": {
       "@mfng:internal": "./src/server/app.tsx",
-      "types": "./lib/src/server/app.d.ts",
       "default": "./lib/src/server/app.js"
     },
     "./package.json": "./package.json",
     "./tailwind.config.cjs": {
       "@mfng:internal": "./tailwind.config.cjs",
-      "types": "./lib/tailwind.config.d.cts",
       "default": "./lib/tailwind.config.cjs"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,22 +13,18 @@
   "exports": {
     "./client": {
       "@mfng:internal": "./src/client/index.ts",
-      "types": "./lib/client/index.d.ts",
       "default": "./lib/client/index.js"
     },
     "./client/browser": {
       "@mfng:internal": "./src/client/browser.ts",
-      "types": "./lib/client/browser.d.ts",
       "default": "./lib/client/browser.js"
     },
     "./server/rsc": {
       "@mfng:internal": "./src/server/rsc.ts",
-      "types": "./lib/server/rsc.d.ts",
       "default": "./lib/server/rsc.js"
     },
     "./server/ssr": {
       "@mfng:internal": "./src/server/ssr.ts",
-      "types": "./lib/server/ssr.d.ts",
       "default": "./lib/server/ssr.js"
     },
     "./use-router-location": {
@@ -40,7 +36,6 @@
     },
     "./router-location-async-local-storage": {
       "@mfng:internal": "./src/server/router-location-async-local-storage.ts",
-      "types": "./lib/server/router-location-async-local-storage.d.ts",
       "default": "./lib/server/router-location-async-local-storage.js"
     }
   },

--- a/packages/webpack-rsc/package.json
+++ b/packages/webpack-rsc/package.json
@@ -13,7 +13,6 @@
   "exports": {
     ".": {
       "@mfng:internal": "./src/index.ts",
-      "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     }
   },


### PR DESCRIPTION
The types can be automatically resolved using extension substitution, see https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports.