### PR TITLE
Handle source maps in webpack loaders

### DIFF
--- a/apps/cloudflare-app/webpack.config.js
+++ b/apps/cloudflare-app/webpack.config.js
@@ -81,6 +81,14 @@ export default function createConfigs(_env, argv) {
   const rscClientLoader = createWebpackRscClientLoader({serverReferencesMap});
 
   /**
+   * @type {import('webpack').RuleSetUseItem}
+   */
+  const serverSwcLoader = {
+    loader: `swc-loader`,
+    options: {env: {targets: {node: 18}}},
+  };
+
+  /**
    * @type {import('webpack').Configuration}
    */
   const serverConfig = {
@@ -122,24 +130,14 @@ export default function createConfigs(_env, argv) {
             {
               issuerLayer: webpackRscLayerName,
               test: /\.tsx?$/,
-              use: [rscServerLoader, `swc-loader`],
+              use: [rscServerLoader, serverSwcLoader],
               exclude: [/node_modules/],
             },
             {
               test: /\.tsx?$/,
-              use: [rscSsrLoader, `swc-loader`],
+              use: [rscSsrLoader, serverSwcLoader],
               exclude: [/node_modules/],
             },
-          ],
-        },
-        {
-          oneOf: [
-            {
-              test: /\.js$/,
-              issuerLayer: webpackRscLayerName,
-              use: rscServerLoader,
-            },
-            {test: /\.js$/, use: rscSsrLoader},
           ],
         },
         cssRule,
@@ -177,7 +175,6 @@ export default function createConfigs(_env, argv) {
     module: {
       rules: [
         {test: /\.js$/, loader: `source-map-loader`, enforce: `pre`},
-        {test: /\.js$/, use: rscClientLoader},
         {
           test: /\.tsx?$/,
           use: [rscClientLoader, `swc-loader`],

--- a/apps/vercel-app/webpack.config.js
+++ b/apps/vercel-app/webpack.config.js
@@ -108,6 +108,14 @@ export default function createConfigs(_env, argv) {
   const rscClientLoader = createWebpackRscClientLoader({serverReferencesMap});
 
   /**
+   * @type {import('webpack').RuleSetUseItem}
+   */
+  const serverSwcLoader = {
+    loader: `swc-loader`,
+    options: {env: {targets: {node: 18}}},
+  };
+
+  /**
    * @type {import('webpack').Configuration}
    */
   const serverConfig = {
@@ -149,25 +157,15 @@ export default function createConfigs(_env, argv) {
             {
               issuerLayer: webpackRscLayerName,
               test: /\.tsx?$/,
-              use: [rscServerLoader, `swc-loader`],
+              use: [rscServerLoader, serverSwcLoader],
               exclude: [/node_modules/],
             },
             {
               test: /\.tsx?$/,
-              use: [rscSsrLoader, `swc-loader`],
+              use: [rscSsrLoader, serverSwcLoader],
               // use: `swc-loader`,
               exclude: [/node_modules/],
             },
-          ],
-        },
-        {
-          oneOf: [
-            {
-              test: /\.js$/,
-              issuerLayer: webpackRscLayerName,
-              use: rscServerLoader,
-            },
-            {test: /\.js$/, use: rscSsrLoader},
           ],
         },
         cssRule,
@@ -218,7 +216,6 @@ export default function createConfigs(_env, argv) {
     module: {
       rules: [
         {test: /\.js$/, loader: `source-map-loader`, enforce: `pre`},
-        {test: /\.js$/, use: rscClientLoader},
         {
           test: /\.tsx?$/,
           use: [rscClientLoader, `swc-loader`],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19839,7 +19839,7 @@
     },
     "packages/webpack-rsc": {
       "name": "@mfng/webpack-rsc",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",

--- a/packages/webpack-rsc/package.json
+++ b/packages/webpack-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mfng/webpack-rsc",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A set of Webpack loaders and plugins for React Server Components",
   "repository": {
     "type": "git",

--- a/packages/webpack-rsc/src/webpack-rsc-ssr-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-ssr-loader.test.ts
@@ -65,18 +65,18 @@ export function bar() {
 
     const output = await callLoader(resourcePath);
 
-    expect(output).toEqual(
+    expect(output.toString().trim()).toEqual(
       `
 // @ts-nocheck
 'use client';
 
 import * as React from 'react';
-export function ClientComponent({
-  action
-}) {
+
+export function ClientComponent({action}) {
   React.useEffect(() => {
     action().then(console.log);
   }, []);
+
   return null;
 }`.trim(),
     );

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,8 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2022",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "sourceMap": true,
+    "inlineSources": true
   }
 }


### PR DESCRIPTION
This enables setting breakpoints in server actions. In addition, we set the swc env to node 18 in the webpack server configs, so that no unnecessary generator code is emitted for async functions, which also messed up the mapped source lines.