### PR TITLE
Pass `formState` directly into `createHtmlStream`

### DIFF
--- a/apps/cloudflare-app/src/worker/index.tsx
+++ b/apps/cloudflare-app/src/worker/index.tsx
@@ -38,6 +38,7 @@ async function renderApp(
     const htmlStream = await createHtmlStream(rscAppStream, {
       reactSsrManifest,
       bootstrapScripts: [jsManifest[`main.js`]!],
+      formState,
     });
 
     return new Response(htmlStream, {

--- a/apps/vercel-app/src/edge-function-handler/index.tsx
+++ b/apps/vercel-app/src/edge-function-handler/index.tsx
@@ -61,6 +61,7 @@ async function renderApp(
     const htmlStream = await createHtmlStream(rscAppStream, {
       reactSsrManifest,
       bootstrapScripts: [jsManifest[`main.js`]!],
+      formState,
     });
 
     return new Response(htmlStream, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19908,7 +19908,7 @@
     },
     "packages/core": {
       "name": "@mfng/core",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "htmlescape": "^1.1.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mfng/core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Core server and client utilities for bootstrapping a React Server Components app",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This avoids the hacky implementation of assigning the form state after server-side rendering has already begun. I believe in the React flight fixture this was only done because RSC rendering and SSR happens in two separate servers. So the form state needed to be extracted from the RSC response stream. Here, we can just pass it around. It seems Next.js is doing that as well (in a more convoluted way, so it's a bit complicated to follow the flow there): https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx

BREAKING CHANGE: The `fomState` now needs to be passed in as part of the options of `createHtmlStream`.