### PR TITLE
Handle export specifiers for client components

### DIFF
--- a/packages/webpack-rsc/src/__fixtures__/client-components.js
+++ b/packages/webpack-rsc/src/__fixtures__/client-components.js
@@ -11,6 +11,22 @@ export const ComponentB = function () {
   return React.createElement(`div`);
 };
 
+export const foo = 1;
+
 export const ComponentC = () => {
   return React.createElement(ClientComponentWithServerAction);
 };
+
+const bar = 2;
+
+const ComponentF = () => React.createElement(`div`);
+
+export {D as ComponentD, bar, ComponentE, ComponentF};
+
+function D() {
+  return React.createElement(`div`);
+}
+
+function ComponentE() {
+  return React.createElement(`div`);
+}

--- a/packages/webpack-rsc/src/webpack-rsc-server-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-server-loader.test.ts
@@ -71,6 +71,9 @@ function createClientReferenceProxy(exportName) {
 export const ComponentA = registerClientReference(createClientReferenceProxy("ComponentA"), "${expectedId}", "ComponentA");
 export const ComponentB = registerClientReference(createClientReferenceProxy("ComponentB"), "${expectedId}", "ComponentB");
 export const ComponentC = registerClientReference(createClientReferenceProxy("ComponentC"), "${expectedId}", "ComponentC");
+export const ComponentD = registerClientReference(createClientReferenceProxy("ComponentD"), "${expectedId}", "ComponentD");
+export const ComponentE = registerClientReference(createClientReferenceProxy("ComponentE"), "${expectedId}", "ComponentE");
+export const ComponentF = registerClientReference(createClientReferenceProxy("ComponentF"), "${expectedId}", "ComponentF");
 `.trim(),
     );
   });


### PR DESCRIPTION
This is a requirement to be able to import from `ai/rsc` (see https://github.com/vercel/ai/blob/6424e9349b568889cb2bc8b8673bbe07429da593/packages/core/rsc/rsc-shared.ts#L9)