### PR TITLE
Add support for inline `'use server'` directives

### DIFF
--- a/packages/webpack-rsc/src/__fixtures__/server-functions-inline-directive.js
+++ b/packages/webpack-rsc/src/__fixtures__/server-functions-inline-directive.js
@@ -1,0 +1,17 @@
+export async function foo() {
+  'use server';
+
+  return `foo`;
+}
+
+export async function bar() {
+  return `bar`;
+}
+
+const b = () => {
+  'use server';
+
+  return `baz`;
+};
+
+export {b as baz};


### PR DESCRIPTION
This is [another](https://github.com/unstubbable/mfng/pull/40) requirement to be able to import from `ai/rsc`, see https://github.com/vercel/ai/blob/6424e9349b568889cb2bc8b8673bbe07429da593/packages/core/rsc/provider.tsx#L28.

_Note: This does not add support for binding of closed-over variables._