### PR TITLE
Handle private server functions with inline `'use server'` directives

### DIFF
--- a/packages/webpack-rsc/src/__fixtures__/server-functions-inline-directive.js
+++ b/packages/webpack-rsc/src/__fixtures__/server-functions-inline-directive.js
@@ -5,7 +5,7 @@ export async function foo() {
 }
 
 export async function bar() {
-  return `bar`;
+  return qux();
 }
 
 const b = () => {
@@ -15,3 +15,9 @@ const b = () => {
 };
 
 export {b as baz};
+
+async function qux() {
+  'use server';
+
+  return `qux`;
+}

--- a/packages/webpack-rsc/src/webpack-rsc-server-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-server-loader.test.ts
@@ -69,9 +69,9 @@ function createClientReferenceProxy(exportName) {
 export const ComponentA = registerClientReference(createClientReferenceProxy("ComponentA"), "${idPrefix}#ComponentA", "ComponentA");
 export const ComponentB = registerClientReference(createClientReferenceProxy("ComponentB"), "${idPrefix}#ComponentB", "ComponentB");
 export const ComponentC = registerClientReference(createClientReferenceProxy("ComponentC"), "${idPrefix}#ComponentC", "ComponentC");
+export const ComponentF = registerClientReference(createClientReferenceProxy("ComponentF"), "${idPrefix}#ComponentF", "ComponentF");
 export const ComponentD = registerClientReference(createClientReferenceProxy("ComponentD"), "${idPrefix}#ComponentD", "ComponentD");
 export const ComponentE = registerClientReference(createClientReferenceProxy("ComponentE"), "${idPrefix}#ComponentE", "ComponentE");
-export const ComponentF = registerClientReference(createClientReferenceProxy("ComponentF"), "${idPrefix}#ComponentF", "ComponentF");
 `.trim(),
     );
   });
@@ -101,16 +101,16 @@ export const ComponentF = registerClientReference(createClientReferenceProxy("Co
           id: `src/__fixtures__/client-components.js#ComponentC`,
         },
         {
+          exportName: `ComponentF`,
+          id: `src/__fixtures__/client-components.js#ComponentF`,
+        },
+        {
           exportName: `ComponentD`,
           id: `src/__fixtures__/client-components.js#ComponentD`,
         },
         {
           exportName: `ComponentE`,
           id: `src/__fixtures__/client-components.js#ComponentE`,
-        },
-        {
-          exportName: `ComponentF`,
-          id: `src/__fixtures__/client-components.js#ComponentF`,
         },
       ],
     });
@@ -132,20 +132,20 @@ import { registerServerReference } from "react-server-dom-webpack/server";
 export async function foo() {
   return Promise.resolve(\`foo\`);
 }
-registerServerReference(foo, module.id, "foo")
+registerServerReference(foo, module.id, "foo");
 export const bar = async () => Promise.resolve(\`bar\`);
-registerServerReference(bar, module.id, "bar")
+registerServerReference(bar, module.id, "bar");
 export const baz = function () {
   quux();
 };
-registerServerReference(baz, module.id, "baz")
+registerServerReference(baz, module.id, "baz");
 export const qux = 42;
 function quux() {}
 `.trim(),
     );
   });
 
-  test(`adds 'registerServerReference' calls to all exported functions that have a 'use server' directive`, async () => {
+  test(`adds 'registerServerReference' calls to all functions that have a 'use server' directive`, async () => {
     const resourcePath = path.resolve(
       currentDirname,
       `__fixtures__/server-functions-inline-directive.js`,
@@ -161,17 +161,24 @@ export async function foo() {
 
   return \`foo\`;
 }
-registerServerReference(foo, module.id, "foo")
+registerServerReference(foo, module.id, "foo");
 export async function bar() {
-  return \`bar\`;
+  return qux();
 }
 const b = () => {
   'use server';
 
   return \`baz\`;
 };
+registerServerReference(b, module.id, "baz");
 export { b as baz };
-registerServerReference(b, module.id, "baz")
+async function qux() {
+  'use server';
+
+  return \`qux\`;
+}
+registerServerReference(qux, module.id, "qux");
+export { qux };
 `.trim(),
     );
   });

--- a/packages/webpack-rsc/src/webpack-rsc-server-plugin.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-server-plugin.test.ts
@@ -164,7 +164,7 @@ __webpack_require__.r(__webpack_exports__);
 async function serverFunctionImportedFromClient() {
   return Promise.resolve(\`server-function-imported-from-client\`);
 }
-(0,react_server_dom_webpack_server__WEBPACK_IMPORTED_MODULE_0__.registerServerReference)(serverFunctionImportedFromClient, module.id, "serverFunctionImportedFromClient")
+(0,react_server_dom_webpack_server__WEBPACK_IMPORTED_MODULE_0__.registerServerReference)(serverFunctionImportedFromClient, module.id, "serverFunctionImportedFromClient");
 
 /***/ }),
 
@@ -185,7 +185,7 @@ __webpack_require__.r(__webpack_exports__);
 async function serverFunctionPassedFromServer() {
   return Promise.resolve(\`server-function-passed-from-server\`);
 }
-(0,react_server_dom_webpack_server__WEBPACK_IMPORTED_MODULE_0__.registerServerReference)(serverFunctionPassedFromServer, module.id, "serverFunctionPassedFromServer")
+(0,react_server_dom_webpack_server__WEBPACK_IMPORTED_MODULE_0__.registerServerReference)(serverFunctionPassedFromServer, module.id, "serverFunctionPassedFromServer");
 
 /***/ }),`,
       );


### PR DESCRIPTION
This is a continuation of #42. What went unnoticed in that PR is that only the webpack RSC server _loader_ can now support inline `'use server'` directives. The Webpack RSC server _plugin_ still needs to be adjusted so that the affected modules are added to the bundle as non-concatenated modules in production mode, so that they can be required by their module ID. This PR does not fix that. But it does add support for server functions with inline `'use server'` directives which are not exported directly, as is the case in https://github.com/vercel/ai/blob/6424e9349b568889cb2bc8b8673bbe07429da593/packages/core/rsc/provider.tsx#L20.