### PR TITLE
Avoid duplicate work being done in RSC server plugin

### DIFF
--- a/apps/cloudflare-app/webpack.config.js
+++ b/apps/cloudflare-app/webpack.config.js
@@ -76,8 +76,13 @@ export default function createConfigs(_env, argv) {
    */
   const clientReferencesMap = new Map();
   const serverReferencesMap = new Map();
-  const rscServerLoader = createWebpackRscServerLoader({clientReferencesMap});
-  const rscSsrLoader = createWebpackRscSsrLoader();
+
+  const rscServerLoader = createWebpackRscServerLoader({
+    clientReferencesMap,
+    serverReferencesMap,
+  });
+
+  const rscSsrLoader = createWebpackRscSsrLoader({serverReferencesMap});
   const rscClientLoader = createWebpackRscClientLoader({serverReferencesMap});
 
   /**

--- a/apps/vercel-app/webpack.config.js
+++ b/apps/vercel-app/webpack.config.js
@@ -103,8 +103,13 @@ export default function createConfigs(_env, argv) {
    */
   const clientReferencesMap = new Map();
   const serverReferencesMap = new Map();
-  const rscServerLoader = createWebpackRscServerLoader({clientReferencesMap});
-  const rscSsrLoader = createWebpackRscSsrLoader();
+
+  const rscServerLoader = createWebpackRscServerLoader({
+    clientReferencesMap,
+    serverReferencesMap,
+  });
+
+  const rscSsrLoader = createWebpackRscSsrLoader({serverReferencesMap});
   const rscClientLoader = createWebpackRscClientLoader({serverReferencesMap});
 
   /**

--- a/packages/webpack-rsc/README.md
+++ b/packages/webpack-rsc/README.md
@@ -41,8 +41,13 @@ import {
 
 const clientReferencesMap = new Map();
 const serverReferencesMap = new Map();
-const rscServerLoader = createWebpackRscServerLoader({clientReferencesMap});
-const rscSsrLoader = createWebpackRscSsrLoader();
+
+const rscServerLoader = createWebpackRscServerLoader({
+  clientReferencesMap,
+  serverReferencesMap,
+});
+
+const rscSsrLoader = createWebpackRscSsrLoader({serverReferencesMap});
 const rscClientLoader = createWebpackRscClientLoader({serverReferencesMap});
 
 const serverConfig = {
@@ -116,8 +121,9 @@ module with client references (objects that contain meta data about the client
 components), and removing all other parts of the client module. It also
 populates the given `clientReferencesMap`.
 
-In addtion, the loader handles server references for React server actions by
-adding meta data to all exported functions of a `use server` module.
+In addition, the loader handles server references for React server actions by
+adding meta data to all exported functions of a `use server` module, and also
+populates the given `serverReferencesMap`.
 
 ### `createWebpackRscSsrLoader`
 
@@ -126,7 +132,8 @@ config. It should be used if the `issuerLayer` is **not** `webpackRscLayerName`.
 This loader is responsible for replacing server actions in a `use server` module
 that are imported from client modules with stubs. The stubs are functions that
 throw an error, since React does not allow calling server actions during SSR (to
-avoid waterfalls). All other parts of the server module are removed.
+avoid waterfalls). All other parts of the server module are removed. It also
+populates the given `serverReferencesMap`.
 
 ### `WebpackRscServerPlugin`
 
@@ -136,7 +143,7 @@ available for server-side rendering (SSR).
 
 The plugin also generates the server manifest that is needed for validating the
 server references of server actions (also known as mutations) that are sent back
-from the client. It also populates the given `serverReferencesMap`.
+from the client. It also adds module IDs to the given `serverReferencesMap`.
 
 ### `createWebpackRscClientLoader`
 

--- a/packages/webpack-rsc/src/index.ts
+++ b/packages/webpack-rsc/src/index.ts
@@ -2,18 +2,17 @@ import {createRequire} from 'module';
 import type {RuleSetUseItem} from 'webpack';
 import type {WebpackRscClientLoaderOptions} from './webpack-rsc-client-loader.cjs';
 import type {WebpackRscServerLoaderOptions} from './webpack-rsc-server-loader.cjs';
+import type {WebpackRscSsrLoaderOptions} from './webpack-rsc-ssr-loader.cjs';
 
-export type {
-  ServerReferencesMap,
-  ServerReferencesModuleInfo,
-  WebpackRscClientLoaderOptions,
-} from './webpack-rsc-client-loader.cjs';
+export type {WebpackRscClientLoaderOptions} from './webpack-rsc-client-loader.cjs';
 
 export * from './webpack-rsc-client-plugin.js';
 
 export type {
   ClientReference,
   ClientReferencesMap,
+  ServerReferencesMap,
+  ServerReferencesModuleInfo,
   WebpackRscServerLoaderOptions,
 } from './webpack-rsc-server-loader.cjs';
 
@@ -30,8 +29,10 @@ export function createWebpackRscServerLoader(
   return {loader: serverLoader, options};
 }
 
-export function createWebpackRscSsrLoader(): RuleSetUseItem {
-  return {loader: ssrLoader};
+export function createWebpackRscSsrLoader(
+  options: WebpackRscSsrLoaderOptions,
+): RuleSetUseItem {
+  return {loader: ssrLoader, options};
 }
 
 export function createWebpackRscClientLoader(

--- a/packages/webpack-rsc/src/webpack-rsc-client-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-client-loader.test.ts
@@ -3,11 +3,9 @@ import path from 'path';
 import url from 'url';
 import {jest} from '@jest/globals';
 import type webpack from 'webpack';
-import type {
-  ServerReferencesMap,
-  WebpackRscClientLoaderOptions,
-} from './webpack-rsc-client-loader.cjs';
+import type {WebpackRscClientLoaderOptions} from './webpack-rsc-client-loader.cjs';
 import webpackRscClientLoader from './webpack-rsc-client-loader.cjs';
+import type {ServerReferencesMap} from './webpack-rsc-server-loader.cjs';
 
 const currentDirname = path.dirname(url.fileURLToPath(import.meta.url));
 

--- a/packages/webpack-rsc/src/webpack-rsc-ssr-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-ssr-loader.test.ts
@@ -3,32 +3,41 @@ import path from 'path';
 import url from 'url';
 import {jest} from '@jest/globals';
 import type webpack from 'webpack';
+import type {ServerReferencesMap} from './webpack-rsc-server-loader.cjs';
+import type {WebpackRscSsrLoaderOptions} from './webpack-rsc-ssr-loader.cjs';
 import webpackRscSsrLoader from './webpack-rsc-ssr-loader.cjs';
 
 const currentDirname = path.dirname(url.fileURLToPath(import.meta.url));
 
-async function callLoader(resourcePath: string): Promise<string | Buffer> {
+async function callLoader(
+  resourcePath: string,
+  serverReferencesMap: ServerReferencesMap,
+): Promise<string | Buffer> {
   const input = await fs.readFile(resourcePath);
 
   return new Promise((resolve, reject) => {
-    const context: Partial<webpack.LoaderContext<{}>> = {
-      resourcePath,
-      cacheable: jest.fn(),
-      callback: (error, content) => {
-        if (error) {
-          reject(error);
-        } else if (content !== undefined) {
-          resolve(content);
-        } else {
-          reject(
-            new Error(`Did not receive any content from webpackRscSsrLoader.`),
-          );
-        }
-      },
-    };
+    const context: Partial<webpack.LoaderContext<WebpackRscSsrLoaderOptions>> =
+      {
+        getOptions: () => ({serverReferencesMap}),
+        resourcePath,
+        cacheable: jest.fn(),
+        callback: (error, content) => {
+          if (error) {
+            reject(error);
+          } else if (content !== undefined) {
+            resolve(content);
+          } else {
+            reject(
+              new Error(
+                `Did not receive any content from webpackRscSsrLoader.`,
+              ),
+            );
+          }
+        },
+      };
 
     void webpackRscSsrLoader.call(
-      context as webpack.LoaderContext<{}>,
+      context as webpack.LoaderContext<WebpackRscSsrLoaderOptions>,
       input.toString(`utf-8`),
     );
   });
@@ -41,7 +50,7 @@ describe(`webpackRscSsrLoader`, () => {
       `__fixtures__/server-functions.js`,
     );
 
-    const output = await callLoader(resourcePath);
+    const output = await callLoader(resourcePath, new Map());
 
     expect(output).toEqual(
       `
@@ -60,13 +69,28 @@ export function baz() {
     );
   });
 
+  test(`populates the given server references map`, async () => {
+    const serverReferencesMap: ServerReferencesMap = new Map();
+
+    const resourcePath = path.resolve(
+      currentDirname,
+      `__fixtures__/server-functions.js`,
+    );
+
+    await callLoader(resourcePath, serverReferencesMap);
+
+    expect(Object.fromEntries([...serverReferencesMap.entries()])).toEqual({
+      [resourcePath]: {exportNames: [`foo`, `bar`, `baz`]},
+    });
+  });
+
   test(`does not change modules without a 'use server' directive`, async () => {
     const resourcePath = path.resolve(
       currentDirname,
       `__fixtures__/client-component.js`,
     );
 
-    const output = await callLoader(resourcePath);
+    const output = await callLoader(resourcePath, new Map());
 
     expect(output.toString().trim()).toEqual(
       `


### PR DESCRIPTION
The RSC server loader already collects all the server references. So we don't need to do the same work again in the plugin. Instead, we can just read them from the provided map. (With a slight disadvantage being that the module IDs can only be added afterwards in the plugin, while also creating the server manifest.) To still support client-side imported server actions, the SSR loader now also needs to collect server references.

This should simplify adding support for inline `'use server'` references to the plugin.

BREAKING CHANGE: The `serverReferencesMap` is now a required option of `createWebpackRscServerLoader`. In addition, it also needs to be passed to `createWebpackRscSsrLoader` (required for server actions that are imported from client components).