### PR TITLE
Ensure `module` is provided by webpack for `module.id` usages

### DIFF
--- a/packages/webpack-rsc/src/webpack-rsc-server-plugin.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-server-plugin.test.ts
@@ -156,7 +156,7 @@ function serverFunctionImportedFromClient() {
 /*!********************************************!*\\
   !*** ./src/__fixtures__/main-component.js ***!
   \\********************************************/
-/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+/***/ ((module, __webpack_exports__, __webpack_require__) => {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -191,7 +191,7 @@ function Main() {
 /*!******************************************************************!*\\
   !*** ./src/__fixtures__/server-function-imported-from-client.js ***!
   \\******************************************************************/
-/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+/***/ ((module, __webpack_exports__, __webpack_require__) => {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -212,7 +212,7 @@ async function serverFunctionImportedFromClient() {
 /*!****************************************************************!*\\
   !*** ./src/__fixtures__/server-function-passed-from-server.js ***!
   \\****************************************************************/
-/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+/***/ ((module, __webpack_exports__, __webpack_require__) => {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -330,7 +330,7 @@ async function serverFunctionPassedFromServer() {
       }
       (0, n.registerServerReference)(
         c,
-        module.id,
+        e.id,
         "serverFunctionWithInlineDirective"
       );
     },
@@ -342,7 +342,7 @@ async function serverFunctionPassedFromServer() {
         t.d(r, { serverFunctionImportedFromClient: () => n }),
         (0, t(324).registerServerReference)(
           n,
-          module.id,
+          e.id,
           "serverFunctionImportedFromClient"
         );
     },
@@ -354,7 +354,7 @@ async function serverFunctionPassedFromServer() {
         t.d(r, { serverFunctionPassedFromServer: () => n }),
         (0, t(324).registerServerReference)(
           n,
-          module.id,
+          e.id,
           "serverFunctionPassedFromServer"
         );
     },`,


### PR DESCRIPTION
Despite the unit tests saying otherwise for some reason (see `__unused_webpack___webpack_module__` occurences), this did already work before this PR, at least in the two MFNG apps. But for the modules with inline `'use server'` directives, we explicitly need to add the runtime requirement, and also set `moduleArgument` to `'module'` so that webpack does not provide `__webpack_module__` instead of `module`.