### PR TITLE
Move `hydrateApp` to `@mfng/core/client/browser`

### DIFF
--- a/apps/aws-app/src/client.tsx
+++ b/apps/aws-app/src/client.tsx
@@ -1,4 +1,4 @@
-import {hydrateApp} from '@mfng/core/client';
+import {hydrateApp} from '@mfng/core/client/browser';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'tailwindcss/tailwind.css';
 

--- a/apps/cloudflare-app/src/client.tsx
+++ b/apps/cloudflare-app/src/client.tsx
@@ -1,4 +1,4 @@
-import {hydrateApp} from '@mfng/core/client';
+import {hydrateApp} from '@mfng/core/client/browser';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'tailwindcss/tailwind.css';
 

--- a/apps/vercel-app/src/client.tsx
+++ b/apps/vercel-app/src/client.tsx
@@ -1,4 +1,4 @@
-import {hydrateApp} from '@mfng/core/client';
+import {hydrateApp} from '@mfng/core/client/browser';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'tailwindcss/tailwind.css';
 

--- a/packages/core/src/client/browser.ts
+++ b/packages/core/src/client/browser.ts
@@ -1,2 +1,3 @@
 export * from './call-server.js';
+export * from './hydrate-app.js';
 export * from './router.js';

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,3 +1,2 @@
-export * from './hydrate-app.js';
 export * from './link.js';
 export * from './use-router.js';

--- a/packages/core/src/client/router.tsx
+++ b/packages/core/src/client/router.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import type {RouterLocation} from '../use-router-location.js';
 import {createUrl, createUrlPath} from './router-location-utils.js';


### PR DESCRIPTION
This is imported from the client/browser entry, so it should be in `@mfng/core/client/browser`, and not in `@mfng/core/client`. The latter has modules that can be used in both, the SSR and browser client. Since `Router` is also imported through the same barrel file, we can remove the `'use client'` directive from it.

Continuation from #53 and #54