### PR TITLE
Increase lambda memory to the equivalent of one vCPU

### DIFF
--- a/apps/aws-app/cdk/stack.ts
+++ b/apps/aws-app/cdk/stack.ts
@@ -28,6 +28,7 @@ export class Stack extends cdk.Stack {
         environment: {
           AWS_HANDLER_VERIFY_HEADER: process.env.AWS_HANDLER_VERIFY_HEADER,
         },
+        memorySize: 1769, // equivalent of one vCPU
       },
     );
 


### PR DESCRIPTION
Let's see if this reduces the response times for server actions.

Source: https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console