### PR TITLE
Source map server actions to their server location

### DIFF
--- a/apps/aws-app/dev-server/run.ts
+++ b/apps/aws-app/dev-server/run.ts
@@ -1,3 +1,6 @@
+import fs from 'fs/promises';
+import path from 'path';
+import url from 'url';
 import {serve} from '@hono/node-server';
 import {serveStatic} from '@hono/node-server/serve-static';
 import {Hono} from 'hono';
@@ -11,6 +14,29 @@ const app = new Hono();
 
 app.use(authMiddleware);
 app.use(`/client/*`, serveStatic({root: `dist/static`}));
+
+app.get(`/source-maps`, async (context) => {
+  const filenameQueryParam = context.req.query(`filename`);
+
+  if (!filenameQueryParam) {
+    return context.newResponse(`Missing query parameter "filename"`, 400);
+  }
+
+  const filename = filenameQueryParam.startsWith(`file://`)
+    ? url.fileURLToPath(filenameQueryParam)
+    : path.join(import.meta.dirname, `../dist/static`, filenameQueryParam);
+
+  try {
+    const sourceMapFilename = `${filename}.map`;
+    const sourceMapContents = await fs.readFile(sourceMapFilename);
+
+    return context.newResponse(sourceMapContents);
+  } catch (error) {
+    console.error(error);
+    return context.newResponse(null, 404);
+  }
+});
+
 app.route(`/`, handlerApp);
 
 const server = serve({fetch: app.fetch, port: 3002}, ({address, port}) => {

--- a/apps/shared-app/src/client/button.tsx
+++ b/apps/shared-app/src/client/button.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import * as React from 'react';
-import {trackClick} from '../server/track-click.js';
 
 export type ButtonProps = React.PropsWithChildren<{
   readonly disabled?: boolean;
+  readonly trackClick: () => Promise<number>;
 }>;
 
-export function Button({children, disabled}: ButtonProps): React.ReactNode {
+export function Button({
+  children,
+  disabled,
+  trackClick,
+}: ButtonProps): React.ReactNode {
   return (
     <button
       onClick={() => void trackClick()}

--- a/apps/shared-app/src/client/product.tsx
+++ b/apps/shared-app/src/client/product.tsx
@@ -3,6 +3,7 @@
 import {clsx} from 'clsx';
 import * as React from 'react';
 import type {BuyResult} from '../server/buy.js';
+import {trackClick} from '../server/track-click.js';
 import {Notification} from '../shared/notification.js';
 import {Button} from './button.js';
 
@@ -43,7 +44,9 @@ export function Product({buy}: ProductProps): React.ReactNode {
         )}
       />
       {` `}
-      <Button disabled={isPending}>Buy now</Button>
+      <Button disabled={isPending} trackClick={trackClick}>
+        Buy now
+      </Button>
       {result && (
         <Notification status={result.status}>
           {result.status === `success` ? (

--- a/packages/core/src/client/hydrate-app.tsx
+++ b/packages/core/src/client/hydrate-app.tsx
@@ -12,11 +12,19 @@ export interface RscAppResult {
   readonly formState?: ReactFormState;
 }
 
+const originRegExp = new RegExp(`^${document.location.origin}`);
+
+export function findSourceMapUrl(filename: string): string | null {
+  return `${document.location.origin}/source-maps?filename=${encodeURIComponent(
+    filename.replace(originRegExp, ``),
+  )}`;
+}
+
 export async function hydrateApp(): Promise<void> {
   const {root: initialRoot, formState} =
     await ReactServerDOMClient.createFromReadableStream<RscAppResult>(
       self.initialRscResponseStream,
-      {callServer},
+      {callServer, findSourceMapURL: findSourceMapUrl},
     );
 
   const initialUrlPath = createUrlPath(document.location);
@@ -25,7 +33,7 @@ export async function hydrateApp(): Promise<void> {
     async function fetchRoot(urlPath: string): Promise<React.ReactElement> {
       const {root} = await ReactServerDOMClient.createFromFetch<RscAppResult>(
         fetch(urlPath, {headers: {accept: `text/x-component`}}),
-        {callServer},
+        {callServer, findSourceMapURL: findSourceMapUrl},
       );
 
       return root;

--- a/packages/webpack-rsc/src/webpack-rsc-client-loader.test.ts
+++ b/packages/webpack-rsc/src/webpack-rsc-client-loader.test.ts
@@ -54,7 +54,7 @@ describe(`webpackRscClientLoader`, () => {
     );
 
     const serverReferencesMap: ServerReferencesMap = new Map([
-      [resourcePath, {moduleId: `test`, exportNames: [`foo`, `bar`]}],
+      [resourcePath, {moduleId: `test`, exportNames: []}],
     ]);
 
     const output = await callLoader(resourcePath, {serverReferencesMap});
@@ -62,9 +62,10 @@ describe(`webpackRscClientLoader`, () => {
     expect(output).toEqual(
       `
 import { createServerReference } from "react-server-dom-webpack/client";
-import { callServer } from "@mfng/core/client/browser";
-export const foo = createServerReference("test#foo", callServer);
-export const bar = createServerReference("test#bar", callServer);
+import { callServer, findSourceMapUrl } from "@mfng/core/client/browser";
+export const foo = createServerReference("test#foo", callServer, undefined, findSourceMapUrl, "foo");
+export const bar = createServerReference("test#bar", callServer, undefined, findSourceMapUrl, "bar");
+export const baz = createServerReference("test#baz", callServer, undefined, findSourceMapUrl, "baz");
 `.trim(),
     );
   });
@@ -86,12 +87,8 @@ export const bar = createServerReference("test#bar", callServer);
       callServerImportSource,
     });
 
-    expect(output).toEqual(
-      `
-import { createServerReference } from "react-server-dom-webpack/client";
-import { callServer } from "some-router/call-server";
-export const foo = createServerReference("test#foo", callServer);
-`.trim(),
+    expect(output).toMatch(
+      `import { callServer, findSourceMapUrl } from "some-router/call-server";`,
     );
   });
 


### PR DESCRIPTION
This enables right-clicking on an action and clicking "Go to definition" in the React DevTools.

https://github.com/user-attachments/assets/82c2938b-f07e-4b0e-98ea-734f38191376

(The serving of the source map files is currently only implemented in the AWS example app's dev server.)